### PR TITLE
Add Google Analytics code

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,16 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="assets/css/main.css" />
+
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-154351745-1"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'UA-154351745-1');
+		</script>
 	</head>
 	<body class="is-preload">
 


### PR DESCRIPTION
## ¿Qué hace esta PR?
Añade el código de seguimiento de Google Analytics, que previamente ha sido creado en la cuenta de @mdelapenya

Según Google:
>La etiqueta global de sitio simplifica la implementación de etiquetas en los productos de remarketing, seguimiento de conversiones y medición, de sitios web de Google, lo que le permite disponer de un mayor control y facilita el proceso de implementación. Al utilizar gtag.js, se beneficiará de las últimas funciones dinámicas e integraciones a medida que estén disponibles

## ¿Por qué es importante?
Nos permitirá trackear las visitas utilizando Google Analytics